### PR TITLE
Update init to work with/without filename

### DIFF
--- a/Classes/JRHostsFile.h
+++ b/Classes/JRHostsFile.h
@@ -1,5 +1,11 @@
 @interface JRHostsFile : NSObject
 
 -(id)init;
+-(id)initWithFileName:(NSString*)fileName;
+
+-(NSString*)defaultFileName;
+-(NSString*)getFileName;
+
+@property (nonatomic,strong) NSString* fileName;
 
 @end

--- a/Classes/JRHostsFile.h
+++ b/Classes/JRHostsFile.h
@@ -3,9 +3,6 @@
 -(id)init;
 -(id)initWithFileName:(NSString*)fileName;
 
--(NSString*)defaultFileName;
--(NSString*)getFileName;
-
-@property (nonatomic,strong) NSString* fileName;
+@property (readonly) NSString* fileName;
 
 @end

--- a/Classes/JRHostsFile.m
+++ b/Classes/JRHostsFile.m
@@ -4,12 +4,28 @@
 
 - (id)init
 {
+    return [self initWithFileName: [self defaultFileName]];
+};
+
+- (id)initWithFileName:(NSString*)fileName
+{
     self = [super init];
+
     if (self)
     {
-        // superclass successfully initialized, further
-        // initialization happens here ...
+        self.fileName = fileName;
     }
     return self;
+};
+
+- (NSString*) defaultFileName
+{
+    return @"/etc/hosts";
+};
+
+- (NSString*) getFileName
+{
+    return self.fileName;
 }
+
 @end

--- a/Classes/JRHostsFile.m
+++ b/Classes/JRHostsFile.m
@@ -2,9 +2,11 @@
 
 @implementation JRHostsFile
 
+NSString* const DefaultFileName = @"/etc/hosts";
+
 - (id)init
 {
-    return [self initWithFileName: [self defaultFileName]];
+    return [self initWithFileName:DefaultFileName];
 };
 
 - (id)initWithFileName:(NSString*)fileName
@@ -13,19 +15,9 @@
 
     if (self)
     {
-        self.fileName = fileName;
+        self->_fileName = fileName;
     }
     return self;
 };
-
-- (NSString*) defaultFileName
-{
-    return @"/etc/hosts";
-};
-
-- (NSString*) getFileName
-{
-    return self.fileName;
-}
 
 @end

--- a/Tests/JRHostsFileTests.m
+++ b/Tests/JRHostsFileTests.m
@@ -7,6 +7,16 @@ describe(@"JRHostsFile", ^{
         JRHostsFile *hostsFile = [[JRHostsFile alloc] init];
         expect(hostsFile).toNot.beNil();
     });
+
+    it(@"initializes with filename that is passed in", ^{
+        JRHostsFile *hostsFile = [[JRHostsFile alloc] initWithFileName:@"test/string"];
+        expect(hostsFile.getFileName).to.equal(@"test/string");
+    });
+
+    it(@"initializes with default filename when no filename is passed in", ^{
+        JRHostsFile *hostsFile = [[JRHostsFile alloc] init];
+        expect(hostsFile.getFileName).to.equal(@"/etc/hosts");
+    });
 });
 
 SpecEnd

--- a/Tests/JRHostsFileTests.m
+++ b/Tests/JRHostsFileTests.m
@@ -10,12 +10,12 @@ describe(@"JRHostsFile", ^{
 
     it(@"initializes with filename that is passed in", ^{
         JRHostsFile *hostsFile = [[JRHostsFile alloc] initWithFileName:@"test/string"];
-        expect(hostsFile.getFileName).to.equal(@"test/string");
+        expect(hostsFile.fileName).to.equal(@"test/string");
     });
 
     it(@"initializes with default filename when no filename is passed in", ^{
         JRHostsFile *hostsFile = [[JRHostsFile alloc] init];
-        expect(hostsFile.getFileName).to.equal(@"/etc/hosts");
+        expect(hostsFile.fileName).to.equal(@"/etc/hosts");
     });
 });
 


### PR DESCRIPTION
@dblock 

Objective-C does not appear to allow default values in methods.  I used the 'designated initializer' pattern to address this.

There is now an initWithFileName method that must be called with a filename.  This is the method that does all initialization work for this class.

If someone calls the standard init, it will call the initWithFileName method using a defaultFileName value (currently set to '/etc/hosts').
